### PR TITLE
4.5.10 Using latest org.json:json dependency

### DIFF
--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
 }
 
-version = '4.5.9'
+version = '4.5.10'
 
 java {
     targetCompatibility = '11'
@@ -30,7 +30,7 @@ dependencies {
         // Define dependency versions as constraints
         api 'org.apache.httpcomponents.client5:httpclient5:5.1.3'
         api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.3'
-        api 'org.json:json:20220924'
+        api 'org.json:json:20230618'
         api 'io.pact.plugin.driver:core:0.3.2'
         api 'org.apache.tika:tika-core:1.28.5'
         


### PR DESCRIPTION
As it is described in issue 1720.
Our projects which are still using Java 11 (and hence unable to upgrade to the latest pact 4.6.3) got a High Severity alert from our Snyk monitoring system.
As our PRs have to pass Snyk scans, this is blocking our workflow.
By using the latest org.json:json dependency in pact the problem could be solved, (tested locally).

Snyk Alert:
Upgrade au.com.dius.pact:consumer@4.5.8 to au.com.dius.pact:consumer@4.6.0 to fix
  ✗ Denial of Service (DoS) [High Severity][[https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-5488379](https://shared.outlook.inky.com/link?domain=security.snyk.io&t=h.eJxlz0ELgjAcBfCvEju3rensr57qFBgUFAQdp05dTifbLCr67rVz18d7P3hvNFuN8gXqvJ9cTqmT1WyVfxI3PnuiDL3PeqTnw3WPi-1li4-nXXE-HnDC0zSGDC0XqA_7VptSaPUSXpkRT8L6UVpHb3dlRbtp8UQqM9AKBK-ahMWSMc7TrORJlNQR1CsJKwExZesMGAdYMwJRwGXAB-F9Jx-kkVqbh9u44eeXUtiAhlYdWn-pD8_Y5wsc-UZh.MEYCIQDAIuxrEN7dUvEYqgNvoMzZ5flYkMpvlZoc3flgQnWfjwIhAMnZcd2jJ6fvXlX85JWu08x0uW0Ij0Se1xnS35si-UVu)] in org.json:json@20220924
    introduced by au.com.dius.pact:consumer@4.5.8 > org.json:json@20220924https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-5488379